### PR TITLE
Add browser-detected darkmode support

### DIFF
--- a/_emails/berkeley.md
+++ b/_emails/berkeley.md
@@ -16,6 +16,7 @@ recipients:
 - RRobinson@cityofberkeley.info
 - ldroste@cityofberkeley.info
 - auditor@cityofberkeley.info
+- policycommittee@cityofberkeley.info
 subject: Berkeley Resident for Defunding BPD
 body: |-
     Dear Mayor Arreguin and Berkeley City Council Members,

--- a/_emails/cambridgema.md
+++ b/_emails/cambridgema.md
@@ -12,7 +12,7 @@ subject: Reduce the Cambridge Police Department budget
 body: |
   Dear City Councilors, Mayor Siddiqui, and City Manager DePasquale,
 
-  My name is [YOUR NAME] and I am a resident of Cambridge. I am writing to demand that the City of Cambridge reduce the Cambridge Police Department budget. Cambridge’s needs must be addressed by the provision of care, and not the threat of violence. We must invest in public services that build towards “a free and fair society” rather than an armed force that endangers us.
+  My name is [YOUR NAME] and I am a resident of Cambridge. I am writing in support of Policy Order #7 to demand that the City of Cambridge reduce the Cambridge Police Department budget. Cambridge’s needs must be addressed by the provision of care, and not the threat of violence. We must invest in public services that build towards “a free and fair society” rather than an armed force that endangers us.
 
   Our city faces racial inequalities, borne from historical injustice and brought into sharp relief by the COVID-19 epidemic, that can’t be solved by policing. Members of our community live in tight quarters and on lean budgets--this before a pandemic stole three months of wages, and counting. Thousands of us are becoming food-insecure and are at risk of eviction as soon as the ban is lifted. Essential educators are living on starvation pay while repeated and overwhelming community demands to right this glaring injustice are ignored.
 

--- a/_emails/chapelhill-active-defund.md
+++ b/_emails/chapelhill-active-defund.md
@@ -1,0 +1,43 @@
+---
+title: Chapel Hill, NC
+permalink: "/chapelhill-active"
+name: Letter to Mayor and City Council, Actively Defund Police
+state: NC
+city: Chapel Hill
+layout: email
+recipients:
+- mayorandcouncil@townofchapelhill.org 
+- phemminger@townofchapelhill.org
+- mparker@townofchapelhill.org
+- janderson@townofchapelhill.org
+- abuansi@townofchapelhill.org
+- hgu@townofchapelhill.org
+- thuynh@townofchapelhill.org
+- aryan@townofchapelhill.org
+- kstegman@townofchapelhill.org
+- mayorandcouncil@townofchapelhill.org
+subject: Please Redistribute Away From and Defund Chapel Hill Police
+body: |
+  Dear Mayor Pam and Chapel Hill Town Council,
+
+  I am asking you all to actively defund the police, to clarify how much Town Council plans to defund the police in advance of the Public Hearing on June 10, and provide evidence of how the initiatives discussed by Mayor Pam "yielded positive results," with statistical or testimonial breakdowns by race or ethnicity. 
+
+  As a resident of Chapel Hill, I am calling you to actively defund the police and limit its reach into our communities, especially those of Black and ethnic minorities. The "slight" cuts mentioned by Mayor Pam, which were already anticipated due to Covid-19, undermines global outcries to actively and intentionally limit the funding of programs that inadvertently promote police brutality, violence, and discrimination. Many of the policies Mayor Pam listed actually work to extend the reach of police violence and discrimination under the guise of progress. I am worried about these initiatives given what I am seeing every day. Who exactly is benefiting and who is being harmed? For example, the Good Neighbor Initiative in Northside, a historically Black community, deserves close scrutiny since it can enable the internal bias and target Black residents when a noise complaint can lead to a court fee, criminal charge, arrest, or murder.
+
+  Council must act and be proactive to redistribute funds away from the police. Although cities and towns across the country have implemented many of the 8cantwait policies mentioned by Mayor Pam, these same cities and towns regularly see the murder and discrimination of Black and minority ethnicities. The 8cantwait policies are not what I am calling for. Rather, the most direct way to avoid police brutality and discrimination is to significantly shift the budget away from the Chapel Hill Police Department.
+
+  I call on Chapel Hill Town Council to take the following actions:
+
+    1. Redirect funds divested from policing to provide educational opportunities, youth programs, environmental justice initiatives, mental health resources, agricultural and food-based inequality programs, sexual assault services, and social work services to our communities.
+  
+    2. Ensure that Covid-19 budget cuts do not affect important community programs but the budget rather be drawn from the Chapel Hill Police Department
+  
+    3. Commit resources to support community-led alternatives to policing, such as social work programs.
+  
+    4. Propose plans for ensuring the safety of Black and other marginalized people in our community from racial profiling by police and other security forces with input from members of the marginalized communities themselves.
+    
+  If Council members in larger cities, such as Minneapolis, Saint Paul, New York, and Los Angeles, are actively working to limit community ties with the police and implement defunding strategies, I am optimistic that the town of Chapel Hill can do the same. I am urging you, Chapel Hill Town Council, to adopt a budget that defunds the police and funds non-violent, community-led, health, and safety strategies. This is a time that will be stamped in public memory, where residents can say whether our Town Council members did or did not actively engage to significantly defund the police.
+
+  Sincerely, 
+  [YOUR NAME] 
+---

--- a/_emails/sanluisobispo.md
+++ b/_emails/sanluisobispo.md
@@ -14,17 +14,17 @@ recipients:
 - estewart@slocity.org
 subject: Budget for the Well-Being of San Luis Obispo
 body: |-
-    Dear San Luis Obispo City Council,
+    Dear Mayor Harmon and San Luis Obispo City Council,
 
     My name is [YOUR NAME] and I am a resident of San Luis Obispo. I am writing to demand that the San Luis Obispo City Council adopt a city budget that prioritizes community well-being, and redirects funding away from the police.
 
-    In 2019, the City of San Luis Obispo allocated 36.3 million dollars to our police system, an inordinate 27.5% of our total budget. This is compared to just $9.7 million allocated towards community development (7.3% of the budget). with only $1.4 million towards housing development.
+    In 2019, the City of San Luis Obispo allocated 36.3 million dollars to our police system, an inordinate 27.5% of our total budget. This is compared to just 7.3% of the budget, $9.7 million, allocated towards community development, with only $1.4 million towards housing development. Next year, the city estimates that there will be a $8.6 million deficit as a result of the pandemic. The city may recoup these funds by decreasing the police budget.
 
-    I demand that the City Council begin meaningfully defunding the San Luis Obispo Police Department and re-allocate those funds to programs proven to more effectively promote a safe and equitable community: community-based mental health services, substance abuse treatment services, affordable housing programs, and more. I demand a budget that reflects the actual needs of San Luis Obispo residents.
+    I demand that the City Council begin meaningfully defunding the San Luis Obispo Police Department and re-allocate those funds to programs proven to more effectively promote a safe and equitable community. We need funding for community-based mental health services, substance abuse treatment services, affordable housing programs, not police. I demand a budget that reflects the actual needs of San Luis Obispo residents.
 
-    History has shown that police "reform" is not enough. We must take a hard look at the way the current system in place fails to serve-and in fact actively harms-our community, and come together to reimagine the role of police in our city.
+    History has shown that police "reform" is not enough. No more money, and more importantly, no more lives must be lost to police. We must take a hard look at the way the current system in place fails to serve-and in fact actively harms-our community, and come together to reimagine the role of police in our city.
 
-    I am urging you to completely revise the budget for the 2020-2021 fiscal year, and to fund care not cops.
+    I am urging you to completely revise the budget for the 2020-2021 fiscal year, and to invest in the people, not the police.
 
     Thank you for your time,
     

--- a/_emails/spokane.md
+++ b/_emails/spokane.md
@@ -1,0 +1,33 @@
+---
+title: Spokane, WA
+permalink: "/spokane"
+name: Letter to Mayor and City Council
+city: Spokane
+state: WA
+layout: email
+recipients:
+- mayor@spokanecity.org
+- bbeggs@spokanecity.org
+- kateburke@spokanecity.org
+- mcathcart@spokanecity.org
+- bwilkerson@spokanecity.org
+- lkinnear@spokanecity.org
+- cmumm@spokanecity.org
+- kstratton@spokanecity.org
+subject: Spokane Resident for Defunding of SPD
+body: |-
+    Dear Mayor Nadine Woodward and Spokane City Council Members,
+
+    My name is [YOUR NAME] and I am a resident of [NEIGHBORHOOD/CITY]. Given the history of policing and the most recent murders of Black people, I am asking you to redirect money away from the Spokane PD in the 2021 budget and instead to prioritize services that help strengthen our communities.
+
+    I want a budget that reflects our community's priorities and needs. I urge you to advocate for a meaningful reallocation of the city's expenditures: away from policing, and towards social programs and resources that support housing, jobs, education, health care, child care, and other critical community needs. Beyond policing our community, these services are proven to be more effective in improving community safety and wellness. I demand a budget that supports community wellbeing, rather than gives power to police forces that tear them apart.
+
+    Please consider your role in enriching and empowering our communities, especially during a time of racial injustice, wide-spread illness, and economic vulnerability.
+
+    Thank you,
+
+    [YOUR NAME]
+    [YOUR ADDRESS]
+    [YOUR EMAIL]
+    [YOUR PHONE NUMBER]
+---

--- a/_layouts/email.html
+++ b/_layouts/email.html
@@ -2,14 +2,14 @@
 
 <div class="content emailPageHeader">
     <div class="container">
-		<h2>{{ page.name }}</h2>
-		<b>{{ page.city }}, {{ page.state }}</b><br /> {{ site.email_intro_text | markdownify }}
-		<p id="autoopen">{{ site.auto_open_message }}</p>
-		<div class='buttons'>
-			<a href="javascript:void(0);" onclick="openEmail()">Send email</a>
-			<a href="javascript:void(0);" onclick="copyToClipboard(this, `{{ page.permalink }}`, true)">Copy link</a>
-		</div>
-		<p>{{ site.bad_mailto_message }}</p>
+        <h2>{{ page.name }}</h2>
+        <b>{{ page.city }}, {{ page.state }}</b><br /> {{ site.email_intro_text | markdownify }}
+        <p id="autoopen">{{ site.auto_open_message }}</p>
+        <div class='buttons'>
+            <a href="javascript:void(0);" onclick="openEmail()">Send email</a>
+            <a href="javascript:void(0);" onclick="copyToClipboard(this, `{{ page.permalink }}`, true)">Copy link</a>
+        </div>
+        <p>{{ site.bad_mailto_message }}</p>
     </div>
 </div>
 
@@ -19,17 +19,17 @@
             <div class="recipients">
                 <b>To:</b> {{ page.recipients | join: ',' }}
                 <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.recipients | join: ',' }}`)">🔗</span>
-			</div>
-			{% if page.cc %}
-			<div class="recipients">
+            </div>
+            {% if page.cc %}
+            <div class="recipients">
                 <b>CC:</b> {{ page.cc | join: ',' }}
                 <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.cc | join: ',' }}`)">🔗</span>
-			</div>
-			{% endif %}
+            </div>
+            {% endif %}
             <div class="recipients">
                 <b>Subject:</b> {{ page.subject }}
                 <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.subject }}`)">🔗</span>
-			</div>
+            </div>
             <div>
                 <b>Message</b> <i>(Don't forget to replace the [x]'s with your information!)</i>
                 <span class="copyToClipboard" onclick="copyToClipboard(this, `{{ page.body }}`)">🔗</span>
@@ -42,23 +42,23 @@
 {% include list.html %}
 
 <script type="text/javascript">
-	function openEmail () {
-		const subject = encodeURIComponent(`{{ page.subject }}`.trim());
-        const body = encodeURIComponent(`{{ page.body }}`.trim());
+    function openEmail() {
+        const subject = encodeURIComponent(`{{ page.subject }}`.trim());
+        const body = encodeURIComponent(`{{ page.body | newline_to_br }}`.trim());
         const recipients = `{{ page.recipients | join: ',' }}`;
         const cc = `{{ page.cc | join: ',' }}`;
         const ccText = cc !== null && cc.length > 0 ? `cc=${cc}&` : ``;
         location.href = `mailto:${recipients}?${ccText}subject=${subject}&body=${body}`;
-	}
+    }
     $(document).ready(() => {
-		const params = getParams(window.location.href)
-		if (params.browse !== undefined) {
-			$("#autoopen").hide()
-			// Automatically updates the URL so if folks try to share, it will auto-open
-			window.history.replaceState({}, document.title, `${window.location.origin}{{ page.permalink }}`)
-		} else {
-			openEmail()
-		}
+        const params = getParams(window.location.href)
+        if (params.browse !== undefined) {
+            $("#autoopen").hide()
+                // Automatically updates the URL so if folks try to share, it will auto-open
+            window.history.replaceState({}, document.title, `${window.location.origin}{{ page.permalink }}`)
+        } else {
+            openEmail()
+        }
     })
 </script>
 


### PR DESCRIPTION
<img width="284" alt="Screen Shot 2020-06-06 at 8 58 41 PM" src="https://user-images.githubusercontent.com/221550/83957727-3dff5500-a838-11ea-9977-128b3891fa99.png" align="right"> 

This PR:

* Changes SCSS variables to [CSS variables](https://caniuse.com/#feat=css-variables)
* Uses the [`prefers-color-scheme` media query](https://caniuse.com/#search=prefers-color-scheme) to change the value of those variables when the browser detects the device uses dark mode

The blue (`#0000ff`) link color is inaccessible on dark backgrounds, so it was changed to the brightest value/saturation in the similar hue group as #0000ff as I deemed reasonable, `#3d81fa`. This color can be changed to something else if it doesn’t fit the intended site aesthetic.

| Light mode (current, default) | Dark mode |
| --- | --- |
| <img width="762" alt="Screen Shot 2020-06-06 at 9 00 42 PM" src="https://user-images.githubusercontent.com/221550/83957783-95052a00-a838-11ea-97ff-cd9093dea6a6.png"> | <img width="760" alt="Screen Shot 2020-06-06 at 9 00 23 PM" src="https://user-images.githubusercontent.com/221550/83957793-9c2c3800-a838-11ea-9d33-176d1c7600aa.png"> |

---

### Future considerations
When the site framework moves to Gatsby/React, I will add support for a toggle UI component so users can choose which version they prefer. 